### PR TITLE
Revert test changes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,6 @@ that is compatible with the IDAES Platform, an advanced process systems engineer
 
 WaterTAP-REFLO (Water treatment Technoeconomic Assessment Platform with Renewable Energy and Flexible Load Optimization) is an extension of WaterTAP that incorporates renewable energy (RE) models for RE-driven desalination systems.
 
-TESTING
-
 Collaborating Institutions
 --------------------------
 


### PR DESCRIPTION
Looks like the old SETO readthedocs project is pointing to an older welcome page (index), but when I go to edit on github through the link provided by RTD, it takes me to the latest index file.

Just undoing my test changes to the readme file