### PR TITLE
Point to watertap 0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author="WaterTAP-REFLO contributors",
     python_requires=">=3.8",
     install_requires=[
-        "watertap == 0.11.0rc1",
+        "watertap == 0.11",
         "nrel-pysam == 3.0.2",
     ],
     extras_require={


### PR DESCRIPTION
With watertap 0.11 officially released, this PR modifies setup.py to point to that release (rather than the release candidate).