### PR TITLE
Point to stable versions of environment dependencies (Pyomo, PySAM)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ setup(
     author="WaterTAP-REFLO contributors",
     python_requires=">=3.8",
     install_requires=[
-        # "watertap == 1.0.0rc0",
-        "watertap @ https://github.com/watertap-org/watertap/archive/main.zip",
+        "watertap == 1.0.0rc0",
+        # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
         "nrel-pysam == 5.1.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,9 @@ setup(
     author="WaterTAP-REFLO contributors",
     python_requires=">=3.8",
     install_requires=[
-        "watertap == 0.11",
-        "nrel-pysam == 5.0.0",
+        "watertap >= 0.12",
+        "pyomo==6.7.1",
+        "nrel-pysam == 5.1.0",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ setup(
     author="WaterTAP-REFLO contributors",
     python_requires=">=3.8",
     install_requires=[
-        "watertap == 0.11",
-        "pyomo==6.7.1",
+        # "watertap == 1.0.0rc0",
+        "watertap @ https://github.com/watertap-org/watertap/archive/main.zip",
         "nrel-pysam == 5.1.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,10 @@ setup(
     author="WaterTAP-REFLO contributors",
     python_requires=">=3.8",
     install_requires=[
-        "watertap == 1.0.0rc0",
         # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
+        "watertap>=1.0.0rc0",
+        "idaes-pse==2.5.0",
+        "pyomo==6.7.3",
         "nrel-pysam == 5.1.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author="WaterTAP-REFLO contributors",
     python_requires=">=3.8",
     install_requires=[
-        "watertap >= 0.12",
+        "watertap == 0.11",
         "pyomo==6.7.1",
         "nrel-pysam == 5.1.0",
     ],


### PR DESCRIPTION
All test will fail with current build from issues with both PySAM and Pyomo/IDAES/WaterTAP dependencies.

This PR reverts to pyomo==6.7.1 and nrel-pysam==5.1.0.