### PR TITLE
Use black version in REFLO environment for GHA

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Install Black
         # unlike the other jobs, we don't need to install watertap-reflo and/or all the dev dependencies,
         # but we still want to specify the Black version to use in requirements-dev.txt for local development

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
 
   linting:
     name: Check code is formatted (Black)
-    # OS and/or Python version don't make a difference, so we choose ubuntu and 3.8 as defaults
+    # OS and/or Python version don't make a difference, so we choose ubuntu and 3.10 as defaults
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,13 +12,24 @@ env:
 jobs:
 
   linting:
+    name: Check code is formatted (Black)
+    # OS and/or Python version don't make a difference, so we choose ubuntu and 3.8 as defaults
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - uses: actions/setup-python@v5
         with:
-          options: "--check --verbose"
-          version: "~= 22.0"
+          python-version: '3.8'
+      - name: Install Black
+        # unlike the other jobs, we don't need to install WaterTAP and/or all the dev dependencies,
+        # but we still want to specify the Black version to use in requirements-dev.txt for local development
+        # so we extract the relevant line and pass it to a simple `pip install`
+        run: |
+          black_requirement="$(grep '^black==' requirements-dev.txt)"
+          pip --no-cache-dir install "$black_requirement"
+      - name: Run Black to verify that the committed code is formatted
+        run: |
+          black --check .
 
   pytest:
     name: pytest (${{ matrix.os }}/${{ matrix.python-version }}/${{ matrix.install-mode }})

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install Black
-        # unlike the other jobs, we don't need to install WaterTAP and/or all the dev dependencies,
+        # unlike the other jobs, we don't need to install watertap-reflo and/or all the dev dependencies,
         # but we still want to specify the Black version to use in requirements-dev.txt for local development
         # so we extract the relevant line and pass it to a simple `pip install`
         run: |

--- a/src/watertap_contrib/reflo/analysis/multiperiod/ltmed_vagmd_semibatch/MED_VAGMD_semibatch_class.py
+++ b/src/watertap_contrib/reflo/analysis/multiperiod/ltmed_vagmd_semibatch/MED_VAGMD_semibatch_class.py
@@ -444,6 +444,7 @@ class MEDVAGMDsemibatchData(UnitModelBlockData):
         self, batch_volume, md_feed_flow_rate, md_feed_salinity, dt
     ):
         blk = self.mp.get_active_process_blocks()[0]
+
         # VAGMD feed temperature and concentration are the same as
         # MED brine at the beginning of the process
         @self.Constraint(

--- a/src/watertap_contrib/reflo/analysis/multiperiod/vagmd_batch/VAGMD_batch_design_model.py
+++ b/src/watertap_contrib/reflo/analysis/multiperiod/vagmd_batch/VAGMD_batch_design_model.py
@@ -396,7 +396,7 @@ def _get_membrane_performance(TEI, FFR, TCI, SgL, module_type, high_brine_salini
     return [PFlux, TCO, TEO, S_c]
 
 
-#%% Test block
+# %% Test block
 
 if __name__ == "__main__":
 

--- a/src/watertap_contrib/reflo/analysis/multiperiod/vagmd_batch/VAGMD_batch_flowsheet_multiperiod.py
+++ b/src/watertap_contrib/reflo/analysis/multiperiod/vagmd_batch/VAGMD_batch_flowsheet_multiperiod.py
@@ -216,9 +216,7 @@ class VAGMDbatchSurrogateData(UnitModelBlockData):
                 self.mp.get_active_process_blocks()[
                     -1
                 ].fs.specific_energy_consumption_thermal
-                * pyunits.convert(
-                    b.system_capacity, to_units=pyunits.m**3 / pyunits.h
-                )
+                * pyunits.convert(b.system_capacity, to_units=pyunits.m**3 / pyunits.h)
             )
 
         @self.Constraint(
@@ -229,9 +227,7 @@ class VAGMDbatchSurrogateData(UnitModelBlockData):
                 self.mp.get_active_process_blocks()[
                     -1
                 ].fs.specific_energy_consumption_electric
-                * pyunits.convert(
-                    b.system_capacity, to_units=pyunits.m**3 / pyunits.h
-                )
+                * pyunits.convert(b.system_capacity, to_units=pyunits.m**3 / pyunits.h)
             )
 
         super().calculate_scaling_factors()

--- a/src/watertap_contrib/reflo/analysis/net_metering/PV_RO.py
+++ b/src/watertap_contrib/reflo/analysis/net_metering/PV_RO.py
@@ -210,12 +210,12 @@ def initialize_treatment(m, water_recovery=0.5):
     ro.feed_side.velocity[0, 0].fix(0.55)  # crossflow velocity (m/s)
     # ro.feed_side.velocity[0, 0].unfix() # crossflow velocity (m/s)
 
-    ro.feed_side.properties_in[0].flow_mass_phase_comp[
-        "Liq", "H2O"
-    ] = p1.control_volume.properties_out[0].flow_mass_phase_comp["Liq", "H2O"]()
-    ro.feed_side.properties_in[0].flow_mass_phase_comp[
-        "Liq", "NaCl"
-    ] = p1.control_volume.properties_out[0].flow_mass_phase_comp["Liq", "NaCl"]()
+    ro.feed_side.properties_in[0].flow_mass_phase_comp["Liq", "H2O"] = (
+        p1.control_volume.properties_out[0].flow_mass_phase_comp["Liq", "H2O"]()
+    )
+    ro.feed_side.properties_in[0].flow_mass_phase_comp["Liq", "NaCl"] = (
+        p1.control_volume.properties_out[0].flow_mass_phase_comp["Liq", "NaCl"]()
+    )
     ro.feed_side.properties_in[0].temperature = feed.properties[0].temperature()
     ro.feed_side.properties_in[0].pressure = p1.control_volume.properties_out[
         0

--- a/src/watertap_contrib/reflo/code_demos/multiperiod_demo_final.ipynb
+++ b/src/watertap_contrib/reflo/code_demos/multiperiod_demo_final.ipynb
@@ -95,7 +95,7 @@
     "from idaes.apps.grid_integration.multiperiod.multiperiod import MultiPeriodModel\n",
     "\n",
     "# WaterTAP import\n",
-    "from watertap.core.solvers import get_solver\n"
+    "from watertap.core.solvers import get_solver"
    ]
   },
   {
@@ -149,7 +149,10 @@
    },
    "outputs": [],
    "source": [
-    "from watertap_contrib.reflo.code_demos.steady_state_flowsheets.simple_RO_unit import ROUnit\n",
+    "from watertap_contrib.reflo.code_demos.steady_state_flowsheets.simple_RO_unit import (\n",
+    "    ROUnit,\n",
+    ")\n",
+    "\n",
     "m.fs.RO = ROUnit()"
    ]
   },
@@ -188,7 +191,8 @@
    "outputs": [],
    "source": [
     "from watertap_contrib.reflo.unit_models.zero_order.battery import BatteryStorage\n",
-    "# From DISPATCHES \n",
+    "\n",
+    "# From DISPATCHES\n",
     "m.fs.battery = BatteryStorage()"
    ]
   },
@@ -241,7 +245,8 @@
    ],
    "source": [
     "from idaes.core.surrogate.pysmo_surrogate import PysmoSurrogate\n",
-    "PV_surrogate = PysmoSurrogate.load_from_file('assets/demo_surrogate.json')"
+    "\n",
+    "PV_surrogate = PysmoSurrogate.load_from_file(\"assets/demo_surrogate.json\")"
    ]
   },
   {
@@ -284,6 +289,7 @@
    "outputs": [],
    "source": [
     "from watertap_contrib.reflo.code_demos.steady_state_flowsheets.system import *\n",
+    "\n",
     "define_system_vars(m)\n",
     "add_steady_state_constraints(m)"
    ]
@@ -334,9 +340,9 @@
    },
    "outputs": [],
    "source": [
-    "m.fs.battery.nameplate_energy.fix(8000) # Battery capacity [kWh]\n",
-    "m.fs.battery.nameplate_power.fix(400) # Battery power [kW]\n",
-    "m.fs.pv_gen.fix(700) # PV generation [kW]"
+    "m.fs.battery.nameplate_energy.fix(8000)  # Battery capacity [kWh]\n",
+    "m.fs.battery.nameplate_power.fix(400)  # Battery power [kW]\n",
+    "m.fs.pv_gen.fix(700)  # PV generation [kW]"
    ]
   },
   {
@@ -447,7 +453,7 @@
     "        (t1.fs.battery.energy_throughput[0], t2.fs.battery.initial_energy_throughput),\n",
     "        (t1.fs.battery.nameplate_power, t2.fs.battery.nameplate_power),\n",
     "        (t1.fs.battery.nameplate_energy, t2.fs.battery.nameplate_energy),\n",
-    "        ]"
+    "    ]"
    ]
   },
   {
@@ -521,36 +527,37 @@
    },
    "outputs": [],
    "source": [
-    "def create_multiperiod_pv_battery_model(\n",
-    "        n_time_points= 24,\n",
-    "        surrogate = None):\n",
-    "    \n",
+    "def create_multiperiod_pv_battery_model(n_time_points=24, surrogate=None):\n",
+    "\n",
     "    # create the multiperiod object\n",
-    "    '''The `MultiPeriodModel` class helps transfer existing steady-state\n",
-    "    process models to multiperiod versions that contain dynamic time coupling'''\n",
+    "    \"\"\"The `MultiPeriodModel` class helps transfer existing steady-state\n",
+    "    process models to multiperiod versions that contain dynamic time coupling\"\"\"\n",
     "    mp = MultiPeriodModel(\n",
     "        n_time_points=n_time_points,\n",
-    "        process_model_func= steady_state_flowsheet,\n",
-    "        linking_variable_func= get_pv_ro_variable_pairs,\n",
-    "        initialization_func= m.fs.battery.initialize(),\n",
-    "        unfix_dof_func= unfix_dof,\n",
+    "        process_model_func=steady_state_flowsheet,\n",
+    "        linking_variable_func=get_pv_ro_variable_pairs,\n",
+    "        initialization_func=m.fs.battery.initialize(),\n",
+    "        unfix_dof_func=unfix_dof,\n",
     "    )\n",
     "\n",
     "    # process_model_func - This is our steady-state or single time instance flowsheet\n",
     "    # unfix_dof - This is where we fix or unfix battery size, power, etc...\n",
     "    # initialize_system - This is where we initialize the battery\n",
-    "    \n",
+    "\n",
     "    # Flowsheet options is where we define the input options for the steady-state flowsheet\n",
-    "    flowsheet_options={ t: { \n",
-    "                            \"pv_gen\": eval_surrogate(surrogate, design_size = 1000, Day = t//24, Hour = t%24),\n",
-    "                            \"electricity_price\": get_elec_tier(Hour = t%24),} \n",
-    "                            for t in range(n_time_points)\n",
+    "    flowsheet_options = {\n",
+    "        t: {\n",
+    "            \"pv_gen\": eval_surrogate(\n",
+    "                surrogate, design_size=1000, Day=t // 24, Hour=t % 24\n",
+    "            ),\n",
+    "            \"electricity_price\": get_elec_tier(Hour=t % 24),\n",
+    "        }\n",
+    "        for t in range(n_time_points)\n",
     "    }\n",
     "\n",
     "    # Build a multi-period capable model using user-provided functions\n",
-    "    mp.build_multi_period_model(\n",
-    "        model_data_kwargs=flowsheet_options)\n",
-    "    \n",
+    "    mp.build_multi_period_model(model_data_kwargs=flowsheet_options)\n",
+    "\n",
     "    # Fix the initial state of charge to zero\n",
     "    mp.blocks[0].process.fs.battery.initial_state_of_charge.fix(0)\n",
     "\n",
@@ -691,6 +698,7 @@
    ],
    "source": [
     "from watertap_contrib.reflo.code_demos.util.visualize import *\n",
+    "\n",
     "create_long_plot(mp)"
    ]
   },
@@ -992,7 +1000,9 @@
     }
    ],
    "source": [
-    "mp_week = create_multiperiod_pv_battery_model(n_time_points=24*7, surrogate=PV_surrogate)\n",
+    "mp_week = create_multiperiod_pv_battery_model(\n",
+    "    n_time_points=24 * 7, surrogate=PV_surrogate\n",
+    ")\n",
     "results = solver.solve(mp_week)\n",
     "print_results(mp_week)"
    ]

--- a/src/watertap_contrib/reflo/costing/units/chemical_softening_zo.py
+++ b/src/watertap_contrib/reflo/costing/units/chemical_softening_zo.py
@@ -462,7 +462,6 @@ def build_chemical_softening_cost_param_block(blk):
     parameter_block_name="chemical_softening",
 )
 def cost_chemical_softening(blk):
-
     """
     Capital and operating costs for chemical softening
     """
@@ -760,29 +759,17 @@ def cost_chemical_softening(blk):
         == (
             (
                 chem_soft.floc_tank_op_coeff_1
-                * (
-                    pyunits.convert(
-                        blk.unit_model.volume_floc, to_units=pyunits.ft**3
-                    )
-                )
+                * (pyunits.convert(blk.unit_model.volume_floc, to_units=pyunits.ft**3))
                 ** chem_soft.floc_tank_op_exp_1
             )
             + (
                 chem_soft.floc_tank_op_coeff_2
-                * (
-                    pyunits.convert(
-                        blk.unit_model.volume_floc, to_units=pyunits.ft**3
-                    )
-                )
+                * (pyunits.convert(blk.unit_model.volume_floc, to_units=pyunits.ft**3))
                 ** chem_soft.floc_tank_op_exp_2
             )
             + (
                 chem_soft.floc_tank_op_coeff_3
-                * (
-                    pyunits.convert(
-                        blk.unit_model.volume_floc, to_units=pyunits.ft**3
-                    )
-                )
+                * (pyunits.convert(blk.unit_model.volume_floc, to_units=pyunits.ft**3))
                 + chem_soft.floc_tank_op_constant
             )
         )

--- a/src/watertap_contrib/reflo/costing/units/lt_med_surrogate.py
+++ b/src/watertap_contrib/reflo/costing/units/lt_med_surrogate.py
@@ -161,10 +161,7 @@ def cost_lt_med_surrogate(blk):
     )
     blk.med_specific_cost_constraint = pyo.Constraint(
         expr=blk.med_specific_cost
-        == (
-            lt_med_params.med_sys_A_coeff
-            * blk.capacity**lt_med_params.med_sys_B_coeff
-        )
+        == (lt_med_params.med_sys_A_coeff * blk.capacity**lt_med_params.med_sys_B_coeff)
     )
     blk.membrane_system_cost_constraint = pyo.Constraint(
         expr=blk.membrane_system_cost

--- a/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
+++ b/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
@@ -177,9 +177,7 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
                 + self.total_operating_cost
             )
             / (
-                pyo.units.convert(
-                    flow_rate, to_units=pyo.units.m**3 / self.base_period
-                )
+                pyo.units.convert(flow_rate, to_units=pyo.units.m**3 / self.base_period)
                 * self.utilization_factor
             ),
             doc=f"Constraint for Levelized Cost of Water based on flow {flow_rate.name}",

--- a/src/watertap_contrib/reflo/property_models/air_water_equilibrium_properties.py
+++ b/src/watertap_contrib/reflo/property_models/air_water_equilibrium_properties.py
@@ -1397,13 +1397,7 @@ class AirWaterEqStateBlockData(StateBlockData):
         def rule_collision_function_zeta_comp(b, j):
             ee = b.collision_function_ee_comp[j]
             return b.collision_function_zeta_comp[j] == (
-                a
-                + b_ * ee
-                + c * ee**2
-                + d * ee**3
-                + e * ee**4
-                + f * ee**5
-                + g * ee**6
+                a + b_ * ee + c * ee**2 + d * ee**3 + e * ee**4 + f * ee**5 + g * ee**6
             )
 
         self.eq_collision_function_zeta_comp = Constraint(

--- a/src/watertap_contrib/reflo/property_models/tests/test_air_water_equilibrium_properties.py
+++ b/src/watertap_contrib/reflo/property_models/tests/test_air_water_equilibrium_properties.py
@@ -88,21 +88,21 @@ def test_parameter_block1(m1):
 
     assert isinstance(m.fs.properties.liq_solute_set, Set)
     assert len(m.fs.properties.liq_solute_set) == 2
-    for (p, j) in m.fs.properties.liq_solute_set:
+    for p, j in m.fs.properties.liq_solute_set:
         assert p == "Liq"
         assert j in m.fs.properties.liq_comps
         assert j in m.fs.properties.component_list
 
     assert isinstance(m.fs.properties.vap_solute_set, Set)
     assert len(m.fs.properties.vap_solute_set) == 2
-    for (p, j) in m.fs.properties.vap_solute_set:
+    for p, j in m.fs.properties.vap_solute_set:
         assert p == "Vap"
         assert j in m.fs.properties.vap_comps
         assert j in m.fs.properties.component_list
 
     assert isinstance(m.fs.properties.phase_solute_set, Set)
     assert len(m.fs.properties.phase_solute_set) == len(m.fs.properties.solute_set) * 2
-    for (p, j) in m.fs.properties.phase_solute_set:
+    for p, j in m.fs.properties.phase_solute_set:
         assert p in m.fs.properties.phase_list
         assert j in m.fs.properties.solute_set
 
@@ -325,21 +325,21 @@ def test_parameter_block2(m2):
 
     assert isinstance(m.fs.properties.liq_solute_set, Set)
     assert len(m.fs.properties.liq_solute_set) == 2
-    for (p, j) in m.fs.properties.liq_solute_set:
+    for p, j in m.fs.properties.liq_solute_set:
         assert p == "Liq"
         assert j in m.fs.properties.liq_comps
         assert j in m.fs.properties.component_list
 
     assert isinstance(m.fs.properties.vap_solute_set, Set)
     assert len(m.fs.properties.vap_solute_set) == 2
-    for (p, j) in m.fs.properties.vap_solute_set:
+    for p, j in m.fs.properties.vap_solute_set:
         assert p == "Vap"
         assert j in m.fs.properties.vap_comps
         assert j in m.fs.properties.component_list
 
     assert isinstance(m.fs.properties.phase_solute_set, Set)
     assert len(m.fs.properties.phase_solute_set) == len(m.fs.properties.solute_set) * 2
-    for (p, j) in m.fs.properties.phase_solute_set:
+    for p, j in m.fs.properties.phase_solute_set:
         assert p in m.fs.properties.phase_list
         assert j in m.fs.properties.solute_set
 
@@ -567,21 +567,21 @@ def test_parameter_block3(m3):
 
     assert isinstance(m.fs.properties.liq_solute_set, Set)
     assert len(m.fs.properties.liq_solute_set) == 2
-    for (p, j) in m.fs.properties.liq_solute_set:
+    for p, j in m.fs.properties.liq_solute_set:
         assert p == "Liq"
         assert j in m.fs.properties.liq_comps
         assert j in m.fs.properties.component_list
 
     assert isinstance(m.fs.properties.vap_solute_set, Set)
     assert len(m.fs.properties.vap_solute_set) == 2
-    for (p, j) in m.fs.properties.vap_solute_set:
+    for p, j in m.fs.properties.vap_solute_set:
         assert p == "Vap"
         assert j in m.fs.properties.vap_comps
         assert j in m.fs.properties.component_list
 
     assert isinstance(m.fs.properties.phase_solute_set, Set)
     assert len(m.fs.properties.phase_solute_set) == len(m.fs.properties.solute_set) * 2
-    for (p, j) in m.fs.properties.phase_solute_set:
+    for p, j in m.fs.properties.phase_solute_set:
         assert p in m.fs.properties.phase_list
         assert j in m.fs.properties.solute_set
 

--- a/src/watertap_contrib/reflo/unit_models/air_stripping_0D.py
+++ b/src/watertap_contrib/reflo/unit_models/air_stripping_0D.py
@@ -1180,22 +1180,22 @@ class AirStripping0DData(InitializationMixin, UnitModelBlockData):
         var_dict[f"Number transfer units [{target}]"] = self.number_transfer_unit[
             target
         ]
-        var_dict[
-            f"Overall mass transfer coeff (KL_a) [{target}]"
-        ] = self.overall_mass_transfer_coeff[target]
+        var_dict[f"Overall mass transfer coeff (KL_a) [{target}]"] = (
+            self.overall_mass_transfer_coeff[target]
+        )
         var_dict["Pressure drop gradient"] = self.pressure_drop_gradient
         var_dict["OTO Model - M parameter"] = self.oto_M
         var_dict["OTO Model - E parameter"] = self.oto_E
         var_dict["OTO Model - F parameter"] = self.oto_F
-        var_dict[
-            f"OTO Model - liquid mass transfer coeff [{target}]"
-        ] = self.oto_mass_transfer_coeff["Liq", target]
-        var_dict[
-            f"OTO Model - vapor mass transfer coeff [{target}]"
-        ] = self.oto_mass_transfer_coeff["Vap", target]
-        var_dict[
-            f"CV mass transfer term [{target}]"
-        ] = self.process_flow.mass_transfer_term[time_point, "Liq", target]
+        var_dict[f"OTO Model - liquid mass transfer coeff [{target}]"] = (
+            self.oto_mass_transfer_coeff["Liq", target]
+        )
+        var_dict[f"OTO Model - vapor mass transfer coeff [{target}]"] = (
+            self.oto_mass_transfer_coeff["Vap", target]
+        )
+        var_dict[f"CV mass transfer term [{target}]"] = (
+            self.process_flow.mass_transfer_term[time_point, "Liq", target]
+        )
         var_dict[f"CV delta P"] = self.process_flow.deltaP[time_point]
         var_dict[f"Blower power required"] = self.blower_power
         var_dict[f"Pump power required"] = self.pump_power

--- a/src/watertap_contrib/reflo/unit_models/surrogate/lt_med_surrogate.py
+++ b/src/watertap_contrib/reflo/unit_models/surrogate/lt_med_surrogate.py
@@ -273,6 +273,7 @@ class LTMEDData(UnitModelBlockData):
         """
         Mass balances
         """
+
         # Distillate flow rate calculation
         @self.Constraint(doc="Distillate volumetric flow rate")
         def eq_dist_vol_flow(b):
@@ -697,9 +698,9 @@ class LTMEDData(UnitModelBlockData):
         var_dict = {}
         var_dict["Gained output ratio"] = self.gain_output_ratio
         var_dict["Thermal power requirement (kW)"] = self.thermal_power_requirement
-        var_dict[
-            "Specific thermal energy consumption (kWh/m3)"
-        ] = self.specific_energy_consumption_thermal
+        var_dict["Specific thermal energy consumption (kWh/m3)"] = (
+            self.specific_energy_consumption_thermal
+        )
         var_dict["Feed water volumetric flow rate"] = self.feed_props[0].flow_vol_phase[
             "Liq"
         ]

--- a/src/watertap_contrib/reflo/unit_models/surrogate/med_tvc_surrogate.py
+++ b/src/watertap_contrib/reflo/unit_models/surrogate/med_tvc_surrogate.py
@@ -293,6 +293,7 @@ class MEDTVCData(UnitModelBlockData):
         """
         Mass balances
         """
+
         # Distillate flow rate calculation
         @self.Constraint(doc="Distallate volumetric flow rate")
         def eq_dist_vol_flow(b):
@@ -834,9 +835,9 @@ class MEDTVCData(UnitModelBlockData):
         var_dict = {}
         var_dict["Gained output ratio"] = self.gain_output_ratio
         var_dict["Thermal power reqruiement (kW)"] = self.thermal_power_requirement
-        var_dict[
-            "Specific thermal energy consumption (kWh/m3)"
-        ] = self.specific_energy_consumption_thermal
+        var_dict["Specific thermal energy consumption (kWh/m3)"] = (
+            self.specific_energy_consumption_thermal
+        )
         var_dict["Feed water volumetric flow rate"] = self.feed_props[0].flow_vol_phase[
             "Liq"
         ]
@@ -1523,8 +1524,7 @@ class MEDTVCData(UnitModelBlockData):
             + 1 * self.motive_steam_mass_flow_rate_coeffs[num_effect][15]
             + self.motive_pressure**2
             * self.motive_steam_mass_flow_rate_coeffs[num_effect][16]
-            + self.capacity**2
-            * self.motive_steam_mass_flow_rate_coeffs[num_effect][17]
+            + self.capacity**2 * self.motive_steam_mass_flow_rate_coeffs[num_effect][17]
             + self.feed_temperature**2
             * self.motive_steam_mass_flow_rate_coeffs[num_effect][18]
             + self.recovery_vol_phase[0, "Liq"] ** 2

--- a/src/watertap_contrib/reflo/unit_models/surrogate/vagmd_surrogate_base.py
+++ b/src/watertap_contrib/reflo/unit_models/surrogate/vagmd_surrogate_base.py
@@ -340,6 +340,7 @@ class VAGMDBaseData(InitializationMixin, UnitModelBlockData):
                 **tmp_dict,
             )
         )
+
         # calculate brine volumetric flow rate
         @self.Constraint(doc="brine volumetric flow rate")
         def eq_brine_volumetric_flow_rate(b):


### PR DESCRIPTION
Edit checks.yml to use the black version specified in the environment build when doing linting test with GHA.

The modified lines in checks.yml are taken directly from checks.yml in main watertap.