### PR TITLE
Add Deep Well Injection unit model and costing

### DIFF
--- a/src/watertap_contrib/reflo/analysis/case_studies/KBHDP/components/deep_well_injection.py
+++ b/src/watertap_contrib/reflo/analysis/case_studies/KBHDP/components/deep_well_injection.py
@@ -124,6 +124,7 @@ def init_DWI(m, blk, verbose=True, solver=None):
 def add_DWI_costing(m, blk):
     blk.unit.costing = UnitModelCostingBlock(
         flowsheet_costing_block=m.fs.costing,
+        costing_method_arguments={"cost_method": "as_opex"}, # could be "as_capex" or "blm"
     )
 
 
@@ -142,6 +143,9 @@ def print_DWI_costing_breakdown(m, blk):
     # print(
     #     f'{"Capital Cost":<30s}{f"${blk.unit.costing.fixed_operating_cost():<25,.0f}"}'
     # )
+    print(
+        f'{"Capital Cost":<30s}{f"${blk.unit.costing.variable_operating_cost():<25,.0f}"}'
+    )
 
 
 def build_system():

--- a/src/watertap_contrib/reflo/analysis/case_studies/KBHDP/components/deep_well_injection.py
+++ b/src/watertap_contrib/reflo/analysis/case_studies/KBHDP/components/deep_well_injection.py
@@ -124,7 +124,9 @@ def init_DWI(m, blk, verbose=True, solver=None):
 def add_DWI_costing(m, blk):
     blk.unit.costing = UnitModelCostingBlock(
         flowsheet_costing_block=m.fs.costing,
-        costing_method_arguments={"cost_method": "as_opex"}, # could be "as_capex" or "blm"
+        costing_method_arguments={
+            "cost_method": "as_opex"
+        },  # could be "as_capex" or "blm"
     )
 
 


### PR DESCRIPTION
This PR will add a simple deep well injection unit model with three costing options:

- calculating OPEX based on user-provided LCOW (calculated such that resulting LCOW will equal this value)
- calculating CAPEX based on user-provided LCOW (calculated such that resulting LCOW will equal this value)
- costing based on BLM deep well injection costing model

TODO:

- [x] add test file
- [x] add costing option for $ per m3 disposed