### PR TITLE
Remove electricity_cost from REFLOSystemCosting build

### DIFF
--- a/src/watertap_contrib/reflo/costing/units/deep_well_injection.py
+++ b/src/watertap_contrib/reflo/costing/units/deep_well_injection.py
@@ -153,7 +153,9 @@ def cost_deep_well_injection_as_opex(blk):
     make_variable_operating_cost_var(blk)
     blk.costing_package.add_cost_factor(blk, None)
 
-    blk.capital_cost.fix(0)
+    blk.capital_cost_constraint = Constraint(
+        expr=blk.capital_cost == 0 * blk.costing_package.base_currency
+    )
 
     blk.base_period_flow = pyunits.convert(
         blk.unit_model.properties[0].flow_vol_phase["Liq"]

--- a/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
+++ b/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
@@ -76,6 +76,7 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
         self.fix_all_vars()
         self.plant_lifetime.fix(20)
         self.utilization_factor.fix(1)
+        self.electricity_cost.fix(0.0718)
 
         # Build the integrated system costs
         self.build_integrated_costs()
@@ -208,7 +209,7 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
                 * self.utilization_factor
             )
             self.add_component("LCOE", LCOE_expr)
-        
+
         else:
             raise NotImplementedError(
                 "add_LCOE for surrogate models not available yet."

--- a/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
+++ b/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
@@ -184,7 +184,7 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
             pysam = self._get_pysam()
 
             if not pysam._has_been_run:
-                raise Exception(
+                raise RuntimeError(
                     f"PySAM model {pysam._pysam_model_name} has not yet been run, so there is no annual_energy data available."
                     "You must run the PySAM model before adding LCOE metric."
                 )
@@ -208,8 +208,8 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
                 * self.utilization_factor
             )
             self.add_component("LCOE", LCOE_expr)
-
-        if e_model == "surrogate":
+        
+        else:
             raise NotImplementedError(
                 "add_LCOE for surrogate models not available yet."
             )

--- a/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
+++ b/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
@@ -72,17 +72,6 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
 
         self.base_currency = pyo.units.USD_2021
 
-        self.del_component(self.electricity_cost)
-
-        self.electricity_cost = pyo.Param(
-            mutable=True,
-            initialize=0.0718,  # From EIA for 2021
-            doc="Electricity cost",
-            units=pyo.units.USD_2021 / pyo.units.kWh,
-        )
-
-        self.register_flow_type("electricity", self.electricity_cost)
-
         # Fix the parameters
         self.fix_all_vars()
         self.plant_lifetime.fix(20)


### PR DESCRIPTION
This is a small PR for a few needed bandaids: 
- remove the electricity_cost Param from REFLOSystemCosting build function that was raising errors
- fix the existing electricity_cost Var to the current value (0.0718)
- add capital_cost_constraint to DWI as_opex costing method
- change type of error raised for add_LCOE() method in REFLOSystemCosting
