### PR TITLE
Correct Calculations in REFLOSystemCosting

### DIFF
--- a/src/watertap_contrib/reflo/costing/tests/test_reflo_watertap_costing_package.py
+++ b/src/watertap_contrib/reflo/costing/tests/test_reflo_watertap_costing_package.py
@@ -51,6 +51,70 @@ from watertap_contrib.reflo.costing.tests.dummy_costing_units import (
 solver = get_solver()
 
 
+def check_proper_aggregation(treat_cost, energy_cost, system_cost):
+    """
+    Test if capital and operating costs from treatment and energy
+    costing blocks are properly aggregated on the system costing block.
+    """
+
+    assert pytest.approx(
+        value(treat_cost.total_capital_cost + energy_cost.total_capital_cost), rel=1e-3
+    ) == value(system_cost.total_capital_cost)
+
+    assert pytest.approx(
+        value(
+            treat_cost.total_fixed_operating_cost
+            + energy_cost.total_fixed_operating_cost
+        ),
+        rel=1e-3,
+    ) == value(system_cost.total_fixed_operating_cost)
+
+    if hasattr(energy_cost, "aggregate_flow_heat"):
+        assert pytest.approx(
+            value(treat_cost.aggregate_flow_heat + energy_cost.aggregate_flow_heat),
+            rel=1e-3,
+        ) == value(system_cost.aggregate_flow_heat)
+
+        assert pytest.approx(value(system_cost.aggregate_flow_heat), rel=1e-3) == value(
+            system_cost.aggregate_flow_heat_purchased
+            - system_cost.aggregate_flow_heat_sold
+        )
+    assert pytest.approx(
+        value(system_cost.aggregate_flow_electricity), rel=1e-3
+    ) == value(
+        system_cost.aggregate_flow_electricity_purchased
+        - system_cost.aggregate_flow_electricity_sold
+    )
+
+    assert pytest.approx(
+        value(
+            treat_cost.aggregate_flow_electricity
+            + energy_cost.aggregate_flow_electricity
+        ),
+        rel=1e-3,
+    ) == value(system_cost.aggregate_flow_electricity)
+
+    assert pytest.approx(
+        value(
+            treat_cost.total_operating_cost
+            - sum(
+                treat_cost.aggregate_flow_costs[f]
+                for f in ["electricity", "heat"]
+                if f in treat_cost.used_flows
+            )
+            + energy_cost.total_operating_cost
+            - sum(
+                energy_cost.aggregate_flow_costs[f]
+                for f in ["electricity", "heat"]
+                if f in energy_cost.used_flows
+            )
+            + system_cost.total_electric_operating_cost
+            + system_cost.total_heat_operating_cost
+        ),
+        rel=1e-3,
+    ) == value(system_cost.total_operating_cost)
+
+
 def build_electricity_gen_only_with_heat():
     """
     Test flowsheet with only electricity generation units on energy block.
@@ -198,6 +262,7 @@ def build_heat_gen_only():
     #### TREATMENT BLOCK
     m.fs.treatment = Block()
     m.fs.treatment.costing = TreatmentCosting()
+    m.fs.treatment.costing.electricity_cost.fix(0.09)
 
     m.fs.treatment.unit = DummyTreatmentUnit(property_package=m.fs.properties)
     m.fs.treatment.unit.costing = UnitModelCostingBlock(
@@ -442,7 +507,7 @@ class TestElectricityGenOnlyWithHeat:
         return m
 
     @pytest.mark.unit
-    def test_build(slef, energy_gen_only_with_heat):
+    def test_build(self, energy_gen_only_with_heat):
 
         m = energy_gen_only_with_heat
 
@@ -517,6 +582,13 @@ class TestElectricityGenOnlyWithHeat:
         ) == value(m.fs.treatment.unit.heat_consumption)
 
     @pytest.mark.component
+    def test_check_proper_aggregation(self, energy_gen_only_with_heat):
+        m = energy_gen_only_with_heat
+        check_proper_aggregation(
+            m.fs.treatment.costing, m.fs.energy.costing, m.fs.costing
+        )
+
+    @pytest.mark.component
     def test_optimize_frac_from_grid(self):
 
         m = build_electricity_gen_only_with_heat()
@@ -575,20 +647,24 @@ class TestElectricityGenOnlyWithHeat:
             + m.fs.energy.costing.aggregate_variable_operating_cost
         )
 
+        check_proper_aggregation(
+            m.fs.treatment.costing, m.fs.energy.costing, m.fs.costing
+        )
+
 
 class TestElectricityGenOnlyNoHeat:
 
     @pytest.fixture(scope="class")
-    def energy_gen_only_no_heat(self):
+    def elec_gen_only_no_heat(self):
 
         m = build_electricity_gen_only_no_heat()
 
         return m
 
     @pytest.mark.unit
-    def test_build(slef, energy_gen_only_no_heat):
+    def test_build(self, elec_gen_only_no_heat):
 
-        m = energy_gen_only_no_heat
+        m = elec_gen_only_no_heat
 
         assert_units_consistent(m)
 
@@ -603,8 +679,8 @@ class TestElectricityGenOnlyNoHeat:
         assert not hasattr(m.fs.costing, "frac_heat_from_grid")
 
     @pytest.mark.component
-    def test_init_and_solve(self, energy_gen_only_no_heat):
-        m = energy_gen_only_no_heat
+    def test_init_and_solve(self, elec_gen_only_no_heat):
+        m = elec_gen_only_no_heat
 
         # constraints are active before initialization
         assert m.fs.costing.total_heat_operating_cost_constraint.active
@@ -685,6 +761,13 @@ class TestElectricityGenOnlyNoHeat:
         )
 
     @pytest.mark.component
+    def test_check_proper_aggregation(self, elec_gen_only_no_heat):
+        m = elec_gen_only_no_heat
+        check_proper_aggregation(
+            m.fs.treatment.costing, m.fs.energy.costing, m.fs.costing
+        )
+
+    @pytest.mark.component
     def test_optimize_frac_from_grid(self):
 
         m = build_electricity_gen_only_no_heat()
@@ -719,6 +802,10 @@ class TestElectricityGenOnlyNoHeat:
         ) == value(
             m.fs.treatment.costing.aggregate_flow_electricity
             + m.fs.energy.costing.aggregate_flow_electricity
+        )
+
+        check_proper_aggregation(
+            m.fs.treatment.costing, m.fs.energy.costing, m.fs.costing
         )
 
 
@@ -804,6 +891,13 @@ class TestHeatGenOnly:
         )
 
     @pytest.mark.component
+    def test_check_proper_aggregation(self, heat_gen_only):
+        m = heat_gen_only
+        check_proper_aggregation(
+            m.fs.treatment.costing, m.fs.energy.costing, m.fs.costing
+        )
+
+    @pytest.mark.component
     def test_optimize_frac_from_grid(self):
 
         m = build_heat_gen_only()
@@ -852,6 +946,10 @@ class TestHeatGenOnly:
             + m.fs.energy.costing.aggregate_variable_operating_cost
         )
 
+        check_proper_aggregation(
+            m.fs.treatment.costing, m.fs.energy.costing, m.fs.costing
+        )
+
 
 class TestElectricityAndHeatGen:
 
@@ -875,7 +973,7 @@ class TestElectricityAndHeatGen:
         return m
 
     @pytest.mark.unit
-    def test_build(slef, heat_and_elec_gen):
+    def test_build(self, heat_and_elec_gen):
 
         m = heat_and_elec_gen
 
@@ -970,6 +1068,13 @@ class TestElectricityAndHeatGen:
         )
 
     @pytest.mark.component
+    def test_check_proper_aggregation(self, heat_and_elec_gen):
+        m = heat_and_elec_gen
+        check_proper_aggregation(
+            m.fs.treatment.costing, m.fs.energy.costing, m.fs.costing
+        )
+
+    @pytest.mark.component
     def test_optimize_frac_from_grid(self):
 
         m = build_heat_and_elec_gen()
@@ -1036,6 +1141,10 @@ class TestElectricityAndHeatGen:
             + m.fs.energy.costing.aggregate_variable_operating_cost
         )
 
+        check_proper_aggregation(
+            m.fs.treatment.costing, m.fs.energy.costing, m.fs.costing
+        )
+
 
 @pytest.mark.component
 def test_no_energy_treatment_block():
@@ -1053,89 +1162,6 @@ def test_no_energy_treatment_block():
         match="REFLOSystemCosting package requires a EnergyCosting block but one was not found\\.",
     ):
         m.fs.costing = REFLOSystemCosting()
-
-
-@pytest.mark.component
-def test_common_params_equivalent():
-
-    m = build_default()
-
-    m.fs.energy.costing.cost_process()
-    m.fs.treatment.costing.cost_process()
-
-    m.fs.energy.costing.electricity_cost.fix(0.02)
-
-    # raise error when electricity costs aren't equivalent
-
-    with pytest.raises(
-        ValueError,
-        match="The common costing parameter electricity_cost was found to "
-        "have a different value on the energy and treatment costing blocks\\. "
-        "Common costing parameters must be equivalent across all"
-        " costing blocks to use REFLOSystemCosting\\.",
-    ):
-        m.fs.costing = REFLOSystemCosting()
-
-    m = build_default()
-
-    m.fs.energy.costing.electricity_cost.fix(0.02)
-    m.fs.treatment.costing.electricity_cost.fix(0.02)
-
-    m.fs.energy.costing.cost_process()
-    m.fs.treatment.costing.cost_process()
-
-    m.fs.costing = REFLOSystemCosting()
-    m.fs.costing.cost_process()
-
-    assert_units_consistent(m)
-
-    # when they are equivalent, assert equivalency across all three costing packages
-
-    assert value(m.fs.costing.electricity_cost) == value(
-        m.fs.treatment.costing.electricity_cost
-    )
-    assert value(m.fs.costing.electricity_cost) == value(
-        m.fs.energy.costing.electricity_cost
-    )
-
-    m = build_default()
-
-    m.fs.treatment.costing.base_currency = pyunits.USD_2011
-
-    m.fs.energy.costing.cost_process()
-    m.fs.treatment.costing.cost_process()
-
-    assert_units_consistent(m)
-
-    # raise error when base currency isn't equivalent
-
-    with pytest.raises(
-        ValueError,
-        match="The common costing parameter base_currency was found to "
-        "have a different value on the energy and treatment costing blocks\\. "
-        "Common costing parameters must be equivalent across all"
-        " costing blocks to use REFLOSystemCosting\\.",
-    ):
-        m.fs.costing = REFLOSystemCosting()
-
-    m = build_default()
-
-    m.fs.treatment.costing.base_currency = pyunits.USD_2011
-    m.fs.energy.costing.base_currency = pyunits.USD_2011
-
-    m.fs.energy.costing.cost_process()
-    m.fs.treatment.costing.cost_process()
-
-    m.fs.costing = REFLOSystemCosting()
-    m.fs.costing.cost_process()
-
-    assert_units_consistent(m)
-
-    # when they are equivalent, assert equivalency across all three costing packages
-
-    assert m.fs.costing.base_currency is pyunits.USD_2011
-    assert m.fs.treatment.costing.base_currency is pyunits.USD_2011
-    assert m.fs.energy.costing.base_currency is pyunits.USD_2011
 
 
 @pytest.mark.component

--- a/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
+++ b/src/watertap_contrib/reflo/costing/watertap_reflo_costing_package.py
@@ -17,6 +17,7 @@ from pyomo.util.calc_var_value import calculate_variable_from_constraint
 from idaes.core import declare_process_block_class
 from idaes.core.util.scaling import get_scaling_factor, set_scaling_factor
 from idaes.core.util.misc import add_object_reference
+import idaes.logger as idaeslog
 
 from watertap.costing.watertap_costing_package import (
     WaterTAPCostingData,
@@ -31,6 +32,8 @@ from watertap_contrib.reflo.solar_models.surrogate.pv.pv_surrogate import (
 from watertap_contrib.reflo.costing.tests.dummy_costing_units import (
     DummyElectricityUnit,
 )
+
+_log = idaeslog.getLogger(__name__)
 
 
 @declare_process_block_class("REFLOCosting")
@@ -192,14 +195,14 @@ class EnergyCostingData(REFLOCostingData):
             initialize=0.005,
             mutable=True,
             units=pyo.units.dimensionless,
-            doc="Yearly performance degradation of electric energy system",
+            doc="Yearly performance degradation of electric generation system",
         )
 
         self.annual_heat_system_degradation = pyo.Param(
             initialize=0.005,
             mutable=True,
             units=pyo.units.dimensionless,
-            doc="Yearly performance degradation of electric energy system",
+            doc="Yearly performance degradation of heat generation system",
         )
 
         self.yearly_electricity_production = pyo.Var(
@@ -314,10 +317,12 @@ class EnergyCostingData(REFLOCostingData):
 
         self.build_LCOE_params()
 
+        # NOTE: electricity_cost must be zero for proper calculation
+
         numerator = pyo.units.convert(
             (
                 self.total_capital_cost * self.capital_recovery_factor
-                + self.aggregate_fixed_operating_cost
+                + self.total_operating_cost
             )
             * self.plant_lifetime,
             to_units=self.base_currency,
@@ -341,10 +346,12 @@ class EnergyCostingData(REFLOCostingData):
 
         self.build_LCOH_params()
 
+        # NOTE: heat_cost must be zero for proper calculation
+
         numerator = pyo.units.convert(
             (
                 self.total_capital_cost * self.capital_recovery_factor
-                + self.aggregate_fixed_operating_cost
+                + self.total_operating_cost
             )
             * self.plant_lifetime,
             to_units=self.base_currency,
@@ -503,17 +510,64 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
             )
         )
 
+        # Remove energy costs from treatment costing to not double count
+        self.treat_operating_cost_no_energy = treat_cost.total_operating_cost - sum(
+            treat_cost.aggregate_flow_costs[f]
+            for f in ["electricity", "heat"]
+            if f in treat_cost.used_flows
+        )
+
+        # Remove energy costs from energy costing to not double count
+        self.energy_operating_cost_no_energy = energy_cost.total_operating_cost - sum(
+            energy_cost.aggregate_flow_costs[f]
+            for f in ["electricity", "heat"]
+            if f in energy_cost.used_flows
+        )
+
+        # For reporting purposes
+        self.total_fixed_operating_cost = pyo.Expression(
+            expr=pyo.units.convert(
+                treat_cost.total_fixed_operating_cost
+                + energy_cost.total_fixed_operating_cost,
+                to_units=self.base_currency / self.base_period,
+            )
+        )
+
+        # For reporting purposes
+        # NOTE: total_operating_cost on treatment and energy costing blocks full equation:
+        # blk.total_operating_cost =
+        #       blk.aggregate_fixed_operating_cost + blk.maintenance_labor_chemical_operating_cost
+        #       + blk.aggregate_variable_operating_cost + sum(blk.aggregate_flow_costs[blk.used_flows])
+        self.total_variable_operating_cost = pyo.Expression(
+            expr=pyo.units.convert(
+                treat_cost.aggregate_variable_operating_cost
+                + energy_cost.aggregate_variable_operating_cost
+                - sum(
+                    treat_cost.aggregate_flow_costs[f]
+                    for f in ["electricity", "heat"]
+                    if f in treat_cost.used_flows
+                )
+                - sum(
+                    energy_cost.aggregate_flow_costs[f]
+                    for f in ["electricity", "heat"]
+                    if f in energy_cost.used_flows
+                ),
+                to_units=self.base_currency / self.base_period,
+            )
+        )
+
         self.total_operating_cost_constraint = pyo.Constraint(
             expr=self.total_operating_cost
             == pyo.units.convert(
-                treat_cost.total_operating_cost
-                + energy_cost.total_operating_cost
+                self.treat_operating_cost_no_energy
+                + self.energy_operating_cost_no_energy
                 + self.total_electric_operating_cost
                 + self.total_heat_operating_cost,
                 to_units=self.base_currency / self.base_period,
             )
         )
-        # energy producer's electricity flow is negative
+
+        # Energy producer's electricity flow is negative
         self.aggregate_electricity_balance = pyo.Constraint(
             expr=(
                 self.aggregate_flow_electricity_purchased
@@ -920,9 +974,11 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
         """
         Check if the common costing parameters across all three costing packages
         (treatment, energy, and system) have the same value.
+        Electricity and heat costs can be different but will log a warning.
         """
 
         common_params = [
+            "total_investment_factor",
             "electricity_cost",
             "heat_cost",
             "electrical_carbon_intensity",
@@ -945,11 +1001,9 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
             else:
                 param_is_equivalent = tp == ep
             if not param_is_equivalent:
-                err_msg = f"The common costing parameter {cp} was found to have a different value "
-                err_msg += f"on the energy and treatment costing blocks. "
-                err_msg += "Common costing parameters must be equivalent across all costing blocks "
-                err_msg += "to use REFLOSystemCosting."
-                raise ValueError(err_msg)
+                warning_msg = f"The common costing parameter {cp} was found to have a different value "
+                warning_msg += f"on the energy and treatment costing blocks. "
+                _log.warning(warning_msg)
 
             if hasattr(self, cp):
                 # if REFLOSystemCosting has this parameter,
@@ -959,6 +1013,30 @@ class REFLOSystemCostingData(WaterTAPCostingBlockData):
                     p.fix(pyo.value(tp))
                 elif isinstance(p, pyo.Param):
                     p.set_value(pyo.value(tp))
+            if cp == "electricity_cost":
+                if pyo.value(treat_cost.electricity_cost) != pyo.value(
+                    self.electricity_cost_buy
+                ):
+                    warning_msg = (
+                        f"The cost of electricity is different on {treat_cost.name} "
+                    )
+                    warning_msg += f"and {self.name} costing blocks."
+                if pyo.value(energy_cost.electricity_cost) != pyo.value(
+                    self.electricity_cost_buy
+                ):
+                    warning_msg = (
+                        f"The cost of electricity is different on {energy_cost.name} "
+                    )
+                    warning_msg += f"and {self.name} costing blocks."
+            if cp == "heat_cost":
+                if pyo.value(treat_cost.heat_cost) != pyo.value(self.heat_cost_buy):
+                    warning_msg = f"The cost of heat is different on {treat_cost.name} "
+                    warning_msg += f"and {self.name} costing blocks."
+                if pyo.value(energy_cost.heat_cost) != pyo.value(self.heat_cost_buy):
+                    warning_msg = (
+                        f"The cost of heat is different on {energy_cost.name} "
+                    )
+                    warning_msg += f"and {self.name} costing blocks."
 
             if cp == "base_currency":
                 self.base_currency = treat_cost.base_currency


### PR DESCRIPTION
This PR corrects some calculations in the costing packages:
- removes the ValueError if common params aren't equal; will instead log warning
- corrects how `total_operating_cost` is calculated at the system level by removing energy and heat costs prior to aggregation
- adds `total_operating_cost` to LCOE/LCOH equations **NOTE: THIS RELIES ON THE ENERGY BEING GENERATED COSTS BEING FIXED TO ZERO.**; i.e., if you have a heat generating unit on the EnergyCosting block, the heat_cost must be fixed to zero for proper calculation of LCOH.
- adds a `total_fixed_operating_cost` Expression and `total_variable_operating_cost` Expression to `REFLOSystemCosting`.
- adds aggregation checks to testing file.