### PR TITLE
Add configuration key to `readthedocs.yaml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@
 
 # Required
 version: 2
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,8 +5,6 @@
 # Required
 version: 2
 sphinx:
-  # Path to your Sphinx configuration file.
-  configuration: docs/conf.py
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
@@ -14,8 +12,9 @@ build:
     python: "3.9"
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  configuration: docs/conf.py
   #TODO: set fail_on_warning to true, once apidoc warnings are figured out
-    fail_on_warning: false
+  fail_on_warning: false
 
 python:
    install:


### PR DESCRIPTION
This PR adds a `configuration` key to the readthedocs.yaml due to a recent deprecation.

see: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/