### PR TITLE
FO unit model modifications

### DIFF
--- a/src/watertap_contrib/reflo/analysis/example_flowsheets/test/test_fo_trevi_flowsheet.py
+++ b/src/watertap_contrib/reflo/analysis/example_flowsheets/test/test_fo_trevi_flowsheet.py
@@ -117,21 +117,21 @@ class TestTreviFO:
         )
         assert overall_performance[
             "Specific thermal energy consumption (kWh/m3)"
-        ] == pytest.approx(26.84, rel=1e-3)
+        ] == pytest.approx(23.40, rel=1e-3)
         assert overall_performance["Thermal power requirement (kW)"] == pytest.approx(
-            569.175, rel=1e-3
+            496.22, rel=1e-3
         )
-        assert overall_performance["LCOW ($/m3)"] == pytest.approx(0.42375, rel=1e-3)
+        assert overall_performance["LCOW ($/m3)"] == pytest.approx(0.860, rel=1e-3)
 
         assert operational_parameters["HX1 cold in temp"] == pytest.approx(
-            21.23, rel=1e-3
+            21.34, rel=1e-3
         )
         assert operational_parameters["HX2 hot out temp"] == pytest.approx(
-            30.636, rel=1e-3
+            25.35, rel=1e-3
         )
         assert operational_parameters["HX1 cold side heat load (MJ)"] == pytest.approx(
             2.0996, rel=1e-3
         )
         assert operational_parameters["HX2 cold side heat load (MJ)"] == pytest.approx(
-            1.5516, rel=1e-3
+            1.189, rel=1e-3
         )

--- a/src/watertap_contrib/reflo/costing/units/forward_osmosis_zo.py
+++ b/src/watertap_contrib/reflo/costing/units/forward_osmosis_zo.py
@@ -74,7 +74,6 @@ def cost_forward_osmosis(blk):
     base_currency = blk.config.flowsheet_costing_block.base_currency
     base_period = blk.config.flowsheet_costing_block.base_period
     make_capital_cost_var(blk)
-    make_fixed_operating_cost_var(blk)
 
     fo = blk.unit_model
     fo_fs = fo.flowsheet()
@@ -89,25 +88,10 @@ def cost_forward_osmosis(blk):
         expr=blk.capital_cost
         == pyo.units.convert(
             fo_params.base_unit_cost
-            * (pyo.units.m**3 / pyo.units.day)
+            * fo_fs.system_capacity
             * (fo_fs.system_capacity * pyo.units.day / pyo.units.m**3)
             ** fo_params.unit_cost_index,
             to_units=base_currency,
-        )
-    )
-
-    blk.fixed_operating_cost_constraint = pyo.Constraint(
-        expr=(
-            blk.fixed_operating_cost
-            == pyo.units.convert(
-                blk.annual_dist_production * fo_params.cost_durable_goods
-                + pyo.units.convert(
-                    brine.flow_vol_phase["Liq"],
-                    to_units=pyo.units.m**3 / pyo.units.year,
-                )
-                * fo_params.cost_disposal,
-                to_units=base_currency / base_period,
-            )
         )
     )
 

--- a/src/watertap_contrib/reflo/property_models/fo_draw_solution_properties.py
+++ b/src/watertap_contrib/reflo/property_models/fo_draw_solution_properties.py
@@ -119,22 +119,22 @@ class FODrawSolutionParameterBlockData(PhysicalParameterBlock):
 
         # osmotic coefficient parameters, equation derived from experimental data
         self.osm_coeff_param_0 = Param(
-            initialize=-2.31586e5,
+            initialize=-1.24602e5,
             units=pyunits.Pa,
             doc="Osmotic coefficient parameter 0",
         )
         self.osm_coeff_param_1 = Param(
-            initialize=9.16006e6,
+            initialize=6.39608e6,
             units=pyunits.Pa,
             doc="Osmotic coefficient parameter 1",
         )
         self.osm_coeff_param_2 = Param(
-            initialize=-3.25759e7,
+            initialize=-2.81942e7,
             units=pyunits.Pa,
             doc="Osmotic coefficient parameter 2",
         )
         self.osm_coeff_param_3 = Param(
-            initialize=5.75176e7,
+            initialize=7.37766e7,
             units=pyunits.Pa,
             doc="Osmotic coefficient parameter 3",
         )

--- a/src/watertap_contrib/reflo/property_models/tests/test_FO_draw_solution_properties.py
+++ b/src/watertap_contrib/reflo/property_models/tests/test_FO_draw_solution_properties.py
@@ -71,7 +71,7 @@ class TestDrawSolutionProperty(PropertyTestHarness):
             ("flow_vol_phase", "Liq"): 9.2170e-4,
             ("conc_mass_phase_comp", ("Liq", "H2O")): 216.975,
             ("conc_mass_phase_comp", ("Liq", "DrawSolution")): 867.899,
-            ("pressure_osm_phase", "Liq"): 1.5697e7,
+            ("pressure_osm_phase", "Liq"): 2.4722e7,
             ("cp_mass_phase", "Liq"): 2257.78,
             ("heat_separation_phase", "Liq"): 0,
         }
@@ -165,7 +165,7 @@ def test_parameters(m):
         6.0171e4, rel=1e-3
     )
     assert value(m.fs.stream[0].pressure_osm_phase["Liq"]) == pytest.approx(
-        9.9468e6, rel=1e-3
+        1.5843e7, rel=1e-3
     )
     assert value(m.fs.stream[0].flow_vol_phase["Liq"]) == pytest.approx(
         1.8459e-3, rel=1e-3

--- a/src/watertap_contrib/reflo/unit_models/zero_order/forward_osmosis_zo.py
+++ b/src/watertap_contrib/reflo/unit_models/zero_order/forward_osmosis_zo.py
@@ -479,9 +479,9 @@ class ForwardOsmosisZOData(UnitModelBlockData):
                     / pyunits.s
                 )
             elif p == "Liq" and j == "TDS":
-                state_args_brine["flow_mass_phase_comp"][(p, j)] = (
-                    state_args["flow_mass_phase_comp"][(p, j)]
-                )
+                state_args_brine["flow_mass_phase_comp"][(p, j)] = state_args[
+                    "flow_mass_phase_comp"
+                ][(p, j)]
 
         blk.brine_props.initialize(
             outlvl=outlvl,

--- a/src/watertap_contrib/reflo/unit_models/zero_order/forward_osmosis_zo.py
+++ b/src/watertap_contrib/reflo/unit_models/zero_order/forward_osmosis_zo.py
@@ -474,9 +474,13 @@ class ForwardOsmosisZOData(UnitModelBlockData):
             if p == "Liq" and j == "H2O":
                 state_args_brine["flow_mass_phase_comp"][(p, j)] = (
                     state_args["flow_mass_phase_comp"][(p, j)]
-                    * (1 - blk.recovery_ratio / blk.nanofiltration_recovery_ratio)
+                    * (1 - blk.recovery_ratio)
                     * pyunits.kg
                     / pyunits.s
+                )
+            elif p == "Liq" and j == "TDS":
+                state_args_brine["flow_mass_phase_comp"][(p, j)] = (
+                    state_args["flow_mass_phase_comp"][(p, j)]
                 )
 
         blk.brine_props.initialize(
@@ -510,7 +514,7 @@ class ForwardOsmosisZOData(UnitModelBlockData):
                     state_args["flow_mass_phase_comp"][(p, j)]
                     * blk.recovery_ratio
                     / blk.nanofiltration_recovery_ratio
-                    * 1.5  # Approximated ratio of the weak draw flow to the feed flow
+                    * 2  # Approximated ratio of the weak draw flow to the feed flow
                     * pyunits.kg
                     / pyunits.s
                 )
@@ -536,7 +540,7 @@ class ForwardOsmosisZOData(UnitModelBlockData):
             elif p == "Liq" and j == "H2O":
                 state_args_strong_draw["flow_mass_phase_comp"][(p, j)] = (
                     state_args_weak_draw["flow_mass_phase_comp"][(p, "DrawSolution")]
-                    * 0.25  # typical draw : water in strong draw solution
+                    * 0.15  # typical draw : water in strong draw solution
                 )
 
         blk.strong_draw_props.initialize(

--- a/src/watertap_contrib/reflo/unit_models/zero_order/tests/test_forward_osmosis.py
+++ b/src/watertap_contrib/reflo/unit_models/zero_order/tests/test_forward_osmosis.py
@@ -222,7 +222,7 @@ class TestFO:
             278.70, rel=1e-3
         )
         assert value(strong_draw.flow_vol_phase["Liq"]) == pytest.approx(
-            1.827, rel=1e-3
+            1.284, rel=1e-3
         )
         assert value(
             weak_draw.flow_mass_phase_comp["Liq", "DrawSolution"]

--- a/src/watertap_contrib/reflo/unit_models/zero_order/tests/test_forward_osmosis.py
+++ b/src/watertap_contrib/reflo/unit_models/zero_order/tests/test_forward_osmosis.py
@@ -228,13 +228,13 @@ class TestFO:
             weak_draw.flow_mass_phase_comp["Liq", "DrawSolution"]
         ) == pytest.approx(1114.80, rel=1e-3)
         assert value(weak_draw.flow_mass_phase_comp["Liq", "H2O"]) == pytest.approx(
-            1497.13, rel=1e-3
+            1379.35, rel=1e-3
         )
-        assert value(weak_draw.flow_vol_phase["Liq"]) == pytest.approx(2.883, rel=1e-3)
+        assert value(weak_draw.flow_vol_phase["Liq"]) == pytest.approx(2.349, rel=1e-3)
         assert value(weak_draw.temperature) == pytest.approx(293.25, rel=1e-3)
         assert value(
             weak_draw.mass_frac_phase_comp["Liq", "DrawSolution"]
-        ) == pytest.approx(0.5140, rel=1e-3)
+        ) == pytest.approx(0.447, rel=1e-3)
         assert value(brine.mass_frac_phase_comp["Liq", "TDS"]) == pytest.approx(
             0.04956, rel=1e-3
         )
@@ -258,9 +258,9 @@ class TestFO:
         assert value(
             reg_draw.flow_mass_phase_comp["Liq", "DrawSolution"]
         ) == pytest.approx(1114.80, rel=1e-3)
-        assert value(m.fs.fo.delta_temp_membrane) == pytest.approx(5.52, rel=1e-3)
-        assert value(m.fs.fo.membrane_temp) == pytest.approx(287.743, rel=1e-3)
+        assert value(m.fs.fo.delta_temp_membrane) == pytest.approx(5.90, rel=1e-3)
+        assert value(m.fs.fo.membrane_temp) == pytest.approx(287.351, rel=1e-3)
         assert value(m.fs.fo.heat_transfer_to_weak_draw) == pytest.approx(
-            33.72, rel=1e-3
+            30.78, rel=1e-3
         )
-        assert value(m.fs.fo.heat_transfer_to_brine) == pytest.approx(41.88, rel=1e-3)
+        assert value(m.fs.fo.heat_transfer_to_brine) == pytest.approx(44.82, rel=1e-3)

--- a/src/watertap_contrib/reflo/unit_models/zero_order/tests/test_forward_osmosis.py
+++ b/src/watertap_contrib/reflo/unit_models/zero_order/tests/test_forward_osmosis.py
@@ -217,16 +217,16 @@ class TestFO:
 
         assert value(
             strong_draw.flow_mass_phase_comp["Liq", "DrawSolution"]
-        ) == pytest.approx(1585.94, rel=1e-3)
+        ) == pytest.approx(1114.80, rel=1e-3)
         assert value(strong_draw.flow_mass_phase_comp["Liq", "H2O"]) == pytest.approx(
-            396.48, rel=1e-3
+            278.70, rel=1e-3
         )
         assert value(strong_draw.flow_vol_phase["Liq"]) == pytest.approx(
             1.827, rel=1e-3
         )
         assert value(
             weak_draw.flow_mass_phase_comp["Liq", "DrawSolution"]
-        ) == pytest.approx(1585.94, rel=1e-3)
+        ) == pytest.approx(1114.80, rel=1e-3)
         assert value(weak_draw.flow_mass_phase_comp["Liq", "H2O"]) == pytest.approx(
             1497.13, rel=1e-3
         )
@@ -253,11 +253,11 @@ class TestFO:
         ) == pytest.approx(13.913, rel=1e-3)
         assert value(product.flow_vol_phase["Liq"]) == pytest.approx(1.389, rel=1e-3)
         assert value(reg_draw.flow_mass_phase_comp["Liq", "H2O"]) == pytest.approx(
-            396.48, rel=1e-3
+            278.80, rel=1e-3
         )
         assert value(
             reg_draw.flow_mass_phase_comp["Liq", "DrawSolution"]
-        ) == pytest.approx(1585.94, rel=1e-3)
+        ) == pytest.approx(1114.80, rel=1e-3)
         assert value(m.fs.fo.delta_temp_membrane) == pytest.approx(5.52, rel=1e-3)
         assert value(m.fs.fo.membrane_temp) == pytest.approx(287.743, rel=1e-3)
         assert value(m.fs.fo.heat_transfer_to_weak_draw) == pytest.approx(


### PR DESCRIPTION
The following modifications were made during the development of Permian FO treatment train and I think they should be merged in the main branch before I push the treatment train flowsheets:
1.  Updated the initial guess values in `forward_osmosis_fo.py`
2.  Updated the osmotic pressure coefficients to adopt a different draw solution in `fo_draw_solution_properties.py`
3.  Removed the `fixed_operating_cost_var ` in the FO cost unit model, because the items considered originally  (chemical and operating) in that variable are doubled counted in the default `maintenance_labor_chemical_operating_cost` item from WaterTAP costing.
4. Associated the CAPEX calculation to system capacity
5. Updated the testing files accordingly.