### PR TITLE
Fix Import for PV Surrogate Demo

### DIFF
--- a/docs/how_to_guides/how_to_run_a_pv_surrogate_model.rst
+++ b/docs/how_to_guides/how_to_run_a_pv_surrogate_model.rst
@@ -23,7 +23,7 @@ The dataset will be generated using 100 samples within this range. For demonstra
 .. code-block:: python
 
     import numpy as np
-    from watertap_contrib.reflo.surrogate import generate_pv_data
+    from watertap_contrib.reflo.solar_models.surrogate import generate_pv_data
 
     weather_file = "path/to/weather/file.csv"  # Update with path to weather file
 


### PR DESCRIPTION
The demo for generating data for the PV surrogate currently has:

`from watertap_contrib.reflo.surrogate import generate_pv_data`

Which doesn't work. It should be:

`from watertap_contrib.reflo.solar_models.surrogate import generate_pv_data`

This PR makes that change.