### PR TITLE
Change `__location__` in KBHDP Solar Energy Component Files

### DIFF
--- a/src/watertap_contrib/reflo/flowsheets/KBHDP/components/CST.py
+++ b/src/watertap_contrib/reflo/flowsheets/KBHDP/components/CST.py
@@ -26,12 +26,10 @@ __all__ = [
 ]
 
 
-__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+__location__ = os.path.dirname(os.path.abspath(__file__))
 par_dir = os.path.dirname(__location__)
 dataset_filename = f"{par_dir}/data/cst/kbhdp_cst_surrogate_data.pkl"
 surrogate_filename = f"{par_dir}/data/cst/kbhdp_cst_surrogate.json"
-# dataset_filename = f"{par_dir}/data/cst/kbhdp_cst_surrogate_data-unscaled.pkl"
-# surrogate_filename = f"{par_dir}/data/cst/kbhdp_cst_surrogate-unscaled.json"
 
 
 def build_system():

--- a/src/watertap_contrib/reflo/flowsheets/KBHDP/components/FPC.py
+++ b/src/watertap_contrib/reflo/flowsheets/KBHDP/components/FPC.py
@@ -24,7 +24,7 @@ __all__ = [
     "print_FPC_costing_breakdown",
 ]
 
-__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+__location__ = os.path.dirname(os.path.abspath(__file__))
 par_dir = os.path.dirname(__location__)
 dataset_filename = f"{par_dir}/data/fpc/kbhdp_fpc_surrogate_data.pkl"
 surrogate_filename = f"{par_dir}/data/fpc/kbhdp_fpc_surrogate.json"

--- a/src/watertap_contrib/reflo/flowsheets/KBHDP/components/PV.py
+++ b/src/watertap_contrib/reflo/flowsheets/KBHDP/components/PV.py
@@ -24,7 +24,7 @@ __all__ = [
     "print_PV_costing_breakdown",
     "report_PV",
 ]
-__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+__location__ = os.path.dirname(os.path.abspath(__file__))
 par_dir = os.path.dirname(__location__)
 dataset_filename = f"{par_dir}/data/pv/kbhdp_pv_surrogate_data.pkl"
 surrogate_filename = f"{par_dir}/data/pv/kbhdp_pv_surrogate.json"


### PR DESCRIPTION
Currently if you:

`from watertap_contrib.reflo.flowsheets.KBHDP import *` 

you get a `[Errno 2] No such file or directory`

this is because currently we are using `os.getcwd()` but should be using:

`__location__ = os.path.dirname(os.path.abspath(__file__))`

