### PR TITLE
Update environment for latest WaterTAP 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
+        #   - "3.9"
           - "3.10"
           - "3.11"
         os:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ setup(
     python_requires=">=3.9",
     install_requires=[
         # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
-        "watertap==1.4.0",
-        "idaes_pse==2.8.0",
-        "pyomo>=6.6.1,<6.9.3",
+        "watertap>=1.6.0",
+        "idaes-pse>=2.10.0",
+        "pyomo>=6.6.1",
         "nrel-pysam>=7.0.0",
         "pint<0.25",
         "requests>=2.32",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_namespace_packages(where="src"),
     package_dir={"": "src"},
     author="WaterTAP-REFLO contributors",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
         # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
         "watertap==1.6.0",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     python_requires=">=3.10",
     install_requires=[
         # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
-        "watertap==1.6.0",
+        "watertap>=1.6.0",
         "idaes-pse>=2.8.0",
         "pyomo>=6.6.1",
         "nrel-pysam>=7.0.0",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     python_requires=">=3.9",
     install_requires=[
         # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
-        "watertap>=1.6.0",
+        "watertap==1.6.0",
         "idaes-pse>=2.8.0",
         "pyomo>=6.10.0",
         "nrel-pysam>=7.0.0",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
         "watertap>=1.6.0",
         "idaes-pse>=2.8.0",
-        "pyomo>=6.6.1",
+        "pyomo>=6.10.0",
         "nrel-pysam>=7.0.0",
         "pint<0.25",
         "requests>=2.32",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
         "watertap>=1.6.0",
-        "idaes-pse>=2.10.0",
+        "idaes-pse>=2.8.0",
         "pyomo>=6.6.1",
         "nrel-pysam>=7.0.0",
         "pint<0.25",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         # "watertap @ https://github.com/watertap-org/watertap/archive/main.zip", # uncomment if we need to point to main mid release cycle
         "watertap==1.6.0",
         "idaes-pse>=2.8.0",
-        "pyomo>=6.10.0",
+        "pyomo>=6.6.1",
         "nrel-pysam>=7.0.0",
         "pint<0.25",
         "requests>=2.32",

--- a/src/watertap_contrib/reflo/flowsheets/KBHDP/KBHDP_ZLD.py
+++ b/src/watertap_contrib/reflo/flowsheets/KBHDP/KBHDP_ZLD.py
@@ -392,7 +392,7 @@ def optimize_zld_ro(m, water_recovery=0.5, fixed_pressure=None, ro_mem_area=None
     for _, stage in treatment.RO.stage.items():
         stage.module.width.setub(5000)
         stage.module.feed_side.velocity[0, 0].unfix()
-        stage.module.feed_side.velocity[0, 1].setlb(0.0)
+        stage.module.feed_side.velocity[0, 1].setlb(0.1)
         stage.module.feed_side.K.setlb(1e-6)
         stage.module.feed_side.friction_factor_darcy.setub(50)
         stage.module.flux_mass_phase_comp.setub(1)

--- a/src/watertap_contrib/reflo/flowsheets/KBHDP/components/ro_system.py
+++ b/src/watertap_contrib/reflo/flowsheets/KBHDP/components/ro_system.py
@@ -382,10 +382,10 @@ def add_ro_scaling(blk):
 
     for _s, stage in blk.stage.items():
         module = stage.module
-        iscale.set_scaling_factor(module.area, 1e5)
+        iscale.set_scaling_factor(module.area, 1)
         iscale.set_scaling_factor(module.feed_side.area, 1)
-        iscale.set_scaling_factor(module.width, 1e4)
-        iscale.set_scaling_factor(module.length, 1e1)
+        iscale.set_scaling_factor(module.width, 1)
+        iscale.set_scaling_factor(module.length, 1)
         iscale.set_scaling_factor(module.feed_side.N_Sh_comp, 1e-4)
 
         for e in module.feed_side.properties:


### PR DESCRIPTION
Trying to use REFLO with watertap-dev install does not work. Primary motivation for this is being able to use PriceTaker with REFLO, which was added in v 1.6

watertap>=1.6.0, idaes-pse>=2.8.0, pyomo>=6.6.1

Also, stop testing Python 3.9.